### PR TITLE
WIP: etoolbox \BeforeBeginEnvironment approach for beamer background scoping

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,17 +9,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pages: write
-      id-token: write
 
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    
     container:
       image: pandoc/latex:3.9
       options: --user root
@@ -30,7 +24,7 @@ jobs:
 
       - name: Install Python and Dependencies
         run: |
-          apk add --no-cache python3 py3-pip py3-yaml make 
+          apk add --no-cache python3 py3-pip py3-yaml make
           tlmgr update --self
           tlmgr install libertine \
                   sourcecodepro \
@@ -54,16 +48,40 @@ jobs:
           /usr/local/dart-sass/sass --version
 
       - name: Build public documents for website
-        run: |
-          make public
+        run: make public
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: build/
+
+  deploy:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: build/
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
-      - name: Upload artifact
+      - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './build'
+          path: build/
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,8 @@ BEAMER_OPTS = -t beamer \
               -V colortheme=owl \
               --pdf-engine=lualatex \
               -V mainfont="Noto Sans" \
-              -V mainfontfallback="NotoColorEmoji:mode=harf"
+              -V mainfontfallback="NotoColorEmoji:mode=harf" \
+              --lua-filter=filters/beamer-background.lua
 
 # --pdf-engine=xelatex
 

--- a/filters/beamer-background.lua
+++ b/filters/beamer-background.lua
@@ -149,13 +149,15 @@ function Pandoc(doc)
       local use_tikz = not is_opaque(opacity)
       if use_tikz then needs_tikz = true end
 
-      -- Set the background before the title frame, then reset it inside the
-      -- title page template (runs after \titlepage, before \end{frame}).
-      local latex = set_background_latex(resolve_image_path(bg), size, opacity) .. "\n" ..
-        "\\addtobeamertemplate{title page}{}{" ..
-        reset_background_latex(use_tikz) .. "}"
+      -- Set the background in the preamble so lualatex applies it to the
+      -- title frame, which pandoc's template emits before $body$.
+      prepend_header_include(meta, set_background_latex(resolve_image_path(bg), size, opacity))
 
-      prepend_header_include(meta, latex)
+      -- Reset the background as the very first body block so that all
+      -- content frames following the title frame have the default background.
+      -- Using \addtobeamertemplate{title page} is unreliable with themes like
+      -- metropolis that replace the title page template entirely.
+      table.insert(new_blocks, 1, pandoc.RawBlock("latex", reset_background_latex(use_tikz)))
     end
   end
 

--- a/filters/beamer-background.lua
+++ b/filters/beamer-background.lua
@@ -22,6 +22,19 @@ local function is_opaque(opacity)
   return opacity == nil or opacity == "" or opacity == "1" or opacity == "1.0"
 end
 
+-- Resolve an image path to absolute so lualatex can find it regardless of
+-- the temp directory it runs from.  Relative paths are resolved against the
+-- directory containing the first input file.
+local function resolve_image_path(image)
+  if pandoc.path.is_absolute(image) then return image end
+  local input = PANDOC_STATE and PANDOC_STATE.input_files and PANDOC_STATE.input_files[1]
+  if not input then return image end
+  local base = pandoc.path.directory(pandoc.path.join({
+    pandoc.system.get_working_directory(), input
+  }))
+  return pandoc.path.join({base, image})
+end
+
 -- Build the LaTeX command that sets the background for one frame.
 local function set_background_latex(image, size, opacity)
   size = size or "cover"
@@ -99,7 +112,7 @@ function Pandoc(doc)
         local use_tikz = not is_opaque(opacity)
         if use_tikz then needs_tikz = true end
         table.insert(new_blocks, pandoc.RawBlock("latex",
-          set_background_latex(bg, size, opacity)))
+          set_background_latex(resolve_image_path(bg), size, opacity)))
         in_bg   = true
         bg_tikz = use_tikz
 
@@ -138,7 +151,7 @@ function Pandoc(doc)
 
       -- Set the background before the title frame, then reset it inside the
       -- title page template (runs after \titlepage, before \end{frame}).
-      local latex = set_background_latex(bg, size, opacity) .. "\n" ..
+      local latex = set_background_latex(resolve_image_path(bg), size, opacity) .. "\n" ..
         "\\addtobeamertemplate{title page}{}{" ..
         reset_background_latex(use_tikz) .. "}"
 

--- a/filters/beamer-background.lua
+++ b/filters/beamer-background.lua
@@ -17,6 +17,23 @@
 --     data-background-image: img/hero.jpg
 --     data-background-size: cover
 --     data-background-opacity: "0.5"      (optional)
+--
+-- ── Strategy ─────────────────────────────────────────────────────────────────
+-- The pandoc beamer template emits the title frame as \frame{\titlepage} and
+-- section-title frames as \frame{\sectionpage}.  The \frame{} command does NOT
+-- trigger etoolbox's \BeforeBeginEnvironment{frame} hook (which only fires for
+-- the environment form \begin{frame}).  Content slides, however, always use
+-- \begin{frame}, so the hook fires reliably for them.
+--
+-- Hybrid approach:
+--   • Title slide  – direct \usebackgroundtemplate in the preamble, cleared by
+--                    a reset injected as the very first body block (before any
+--                    \begin{frame} or \frame{\sectionpage}).
+--   • Content slides – a global flag (\ifbgpending) is armed just before the
+--                    target \begin{frame}; \BeforeBeginEnvironment{frame} reads
+--                    the flag and either applies or resets the background at
+--                    the true outer TeX level, avoiding all \aftergroup /
+--                    \egroup layering problems.
 
 local function is_opaque(opacity)
   return opacity == nil or opacity == "" or opacity == "1" or opacity == "1.0"
@@ -35,7 +52,8 @@ local function resolve_image_path(image)
   return pandoc.path.join({base, image})
 end
 
--- Build the LaTeX command that sets the background for one frame.
+-- ── Title-slide helpers (direct template, same as original approach) ──────────
+
 local function set_background_latex(image, size, opacity)
   size = size or "cover"
   local img_opts
@@ -51,7 +69,6 @@ local function set_background_latex(image, size, opacity)
       img_opts, image
     )
   else
-    -- Opacity requires TikZ overlay
     return string.format(
       "\\setbeamertemplate{background}{%%\n" ..
       "  \\begin{tikzpicture}[remember picture,overlay]\n" ..
@@ -64,14 +81,96 @@ local function set_background_latex(image, size, opacity)
   end
 end
 
--- Build the LaTeX command that clears the background after a frame.
-local function reset_background_latex(used_tikz)
-  if used_tikz then
-    return "\\setbeamertemplate{background}{}"
-  else
-    return "\\usebackgroundtemplate{}"
-  end
+-- Schedule a one-shot background reset that fires AFTER the title page ships
+-- out (using LaTeX 2020's \AddToHookNext).  This avoids inserting a raw block
+-- in the document body, which pandoc would wrap in an extra blank \begin{frame}
+-- and produce a spurious blank page between the title and the first section.
+local function title_reset_latex()
+  return table.concat({
+    "% Reset background after the title page ships (one-shot hook).",
+    "\\AddToHookNext{shipout/after}{%",
+    "  \\usebackgroundtemplate{}%",
+    "  \\setbeamertemplate{background}{}%",
+    "}",
+  }, "\n")
 end
+
+-- ── Content-slide helpers (flag + BeforeBeginEnvironment hook) ────────────────
+
+-- Arm the global flag just before a \begin{frame}.
+-- \BeforeBeginEnvironment{frame} will read these globals and apply or clear
+-- the background at the outer TeX level (before any frame group is opened),
+-- then clear the flag so all subsequent frames revert automatically.
+local function set_pending_latex(image, size, opacity)
+  size = size or "cover"
+  local lines = {
+    string.format("\\gdef\\bgpendingimage{%s}", image),
+    string.format("\\gdef\\bgpendingsize{%s}",  size),
+  }
+  if is_opaque(opacity) then
+    table.insert(lines, "\\global\\bgopaquetrue")
+  else
+    table.insert(lines, string.format("\\gdef\\bgpendingopc{%s}", opacity))
+    table.insert(lines, "\\global\\bgopaquefalse")
+  end
+  table.insert(lines, "\\global\\bgpendingtrue")
+  return table.concat(lines, "\n")
+end
+
+-- Preamble block: defines the \BeforeBeginEnvironment{frame} hook and the
+-- global variables it uses.  Installed only when at least one content slide
+-- requests a background.
+local PREAMBLE_HOOK = [[
+\usepackage{etoolbox}
+\newif\ifbgpending
+\newif\ifbgopaque
+\global\bgpendingfalse
+\global\bgopaquetrue
+\gdef\bgpendingimage{}
+\gdef\bgpendingsize{cover}
+\gdef\bgpendingopc{1}
+% This hook fires at the true outer TeX level, before \begin{frame} opens
+% any group, so assignments here are safe and global without \global.
+\BeforeBeginEnvironment{frame}{%
+  \ifbgpending
+    \def\tmpbgsize{\bgpendingsize}%
+    \def\tmpcontain{contain}%
+    \ifbgopaque
+      \ifx\tmpbgsize\tmpcontain
+        \usebackgroundtemplate{%
+          \includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio]%
+            {\bgpendingimage}}%
+      \else
+        \usebackgroundtemplate{%
+          \includegraphics[width=\paperwidth,height=\paperheight]%
+            {\bgpendingimage}}%
+      \fi
+    \else
+      \ifx\tmpbgsize\tmpcontain
+        \setbeamertemplate{background}{%
+          \begin{tikzpicture}[remember picture,overlay]
+            \node[opacity=\bgpendingopc] at (current page.center)
+              {\includegraphics[width=\paperwidth,height=\paperheight,
+                                keepaspectratio]{\bgpendingimage}};
+          \end{tikzpicture}}%
+      \else
+        \setbeamertemplate{background}{%
+          \begin{tikzpicture}[remember picture,overlay]
+            \node[opacity=\bgpendingopc] at (current page.center)
+              {\includegraphics[width=\paperwidth,height=\paperheight]%
+                {\bgpendingimage}};
+          \end{tikzpicture}}%
+      \fi
+    \fi
+    \global\bgpendingfalse
+    \global\bgopaquetrue
+  \else
+    % No background pending: reset both template slots so that a background
+    % from a previous slide does not bleed into this one.
+    \usebackgroundtemplate{}%
+    \setbeamertemplate{background}{}%
+  \fi
+}]]
 
 -- Prepend an item to a MetaList (or create one from a single value).
 local function prepend_header_include(meta, raw_latex)
@@ -89,32 +188,28 @@ end
 function Pandoc(doc)
   if FORMAT ~= "beamer" then return nil end
 
-  local new_blocks = {}
-  local in_bg      = false   -- currently inside a slide with a custom background
-  local bg_tikz    = false   -- that background uses TikZ (opacity)
-  local needs_tikz = false   -- any opacity was requested anywhere in the doc
+  local new_blocks     = {}
+  local has_content_bg = false   -- any ## slide requests a background
+  local needs_tikz     = false   -- any opacity was used anywhere
 
+  -- ── Content slides: inject flag-setter before each background heading ───────
   for _, block in ipairs(doc.blocks) do
-    -- A new section (level 1) or slide (level 2) ends any active background.
     if block.t == "Header" and (block.level == 1 or block.level == 2) then
-      if in_bg then
-        table.insert(new_blocks, pandoc.RawBlock("latex", reset_background_latex(bg_tikz)))
-        in_bg   = false
-        bg_tikz = false
-      end
-
-      -- Check whether this header carries a background-image attribute.
       local bg      = block.attr.attributes["background-image"]
       local size    = block.attr.attributes["background-size"]
       local opacity = block.attr.attributes["background-opacity"]
 
       if bg then
-        local use_tikz = not is_opaque(opacity)
-        if use_tikz then needs_tikz = true end
+        has_content_bg = true
+        if not is_opaque(opacity) then needs_tikz = true end
+
+        -- Arm the flag just before the heading; even if this raw block ends
+        -- up inside the previous frame (inside a block environment), the
+        -- \gdef / \global assignments are unconditionally global in TeX and
+        -- will be visible when \BeforeBeginEnvironment{frame} fires for the
+        -- *next* \begin{frame}.
         table.insert(new_blocks, pandoc.RawBlock("latex",
-          set_background_latex(resolve_image_path(bg), size, opacity)))
-        in_bg   = true
-        bg_tikz = use_tikz
+          set_pending_latex(resolve_image_path(bg), size, opacity)))
 
         -- Strip background attrs so Beamer doesn't trip on unknown keys.
         block.attr.attributes["background-image"]   = nil
@@ -126,14 +221,14 @@ function Pandoc(doc)
     table.insert(new_blocks, block)
   end
 
-  -- Close any background that was still open at the end of the document.
-  if in_bg then
-    table.insert(new_blocks, pandoc.RawBlock("latex", reset_background_latex(bg_tikz)))
-  end
-
-  -- -------------------------------------------------------------------------
-  -- Title slide: honour data-background-image from title-slide-attributes.
-  -- -------------------------------------------------------------------------
+  -- ── Title slide: direct template in preamble + post-shipout reset ───────────
+  -- \frame{\titlepage} does NOT trigger \BeforeBeginEnvironment{frame}, so the
+  -- flag mechanism cannot be used.  Instead the template is set directly in the
+  -- preamble and a \AddToHookNext{shipout/after} one-shot hook resets it after
+  -- the title page ships.  (Inserting a raw reset block in the document body
+  -- would cause pandoc to wrap it in a spurious blank \begin{frame}.)
+  -- NOTE: section-separator pages also use \frame{\sectionpage} and are equally
+  -- invisible to the hook; the shipout reset targets them too.
   local meta = doc.meta
   local tsa  = meta["title-slide-attributes"]
   if tsa then
@@ -149,23 +244,23 @@ function Pandoc(doc)
       local use_tikz = not is_opaque(opacity)
       if use_tikz then needs_tikz = true end
 
-      -- Set the background in the preamble so lualatex applies it to the
-      -- title frame, which pandoc's template emits before $body$.
-      prepend_header_include(meta, set_background_latex(resolve_image_path(bg), size, opacity))
+      prepend_header_include(meta,
+        set_background_latex(resolve_image_path(bg), size, opacity))
 
-      -- Reset the background as the very first body block so that all
-      -- content frames following the title frame have the default background.
-      -- Using \addtobeamertemplate{title page} is unreliable with themes like
-      -- metropolis that replace the title page template entirely.
-      table.insert(new_blocks, 1, pandoc.RawBlock("latex", reset_background_latex(use_tikz)))
+      -- Schedule a one-shot reset that fires after the title page ships out.
+      -- Inserting a raw LaTeX reset as the first body block would cause pandoc
+      -- to wrap it in an extra \begin{frame}, creating a spurious blank page.
+      prepend_header_include(meta, title_reset_latex())
     end
   end
 
-  -- -------------------------------------------------------------------------
-  -- Load TikZ if any opacity was requested.
-  -- -------------------------------------------------------------------------
-  if needs_tikz then
-    prepend_header_include(meta, "\\usepackage{tikz}")
+  -- ── Preamble: install hook infrastructure (content slides only) ─────────────
+  if has_content_bg then
+    if needs_tikz then
+      prepend_header_include(meta, "\\usepackage{tikz}")
+    end
+    -- PREAMBLE_HOOK goes first (outermost prepend applied last).
+    prepend_header_include(meta, PREAMBLE_HOOK)
   end
 
   return pandoc.Pandoc(new_blocks, meta)

--- a/filters/beamer-background.lua
+++ b/filters/beamer-background.lua
@@ -1,0 +1,157 @@
+-- beamer-background.lua
+--
+-- Adds per-slide background image support for Beamer PDF output.
+-- Reads the same attributes used by reveal.js, so slides work across
+-- both output formats without any changes to the Markdown source.
+--
+-- Supported attributes on ## headings:
+--   background-image="img/foo.jpg"        (required)
+--   background-size="cover"               (optional; "cover" or "contain", default: cover)
+--   background-opacity="0.4"              (optional; 0.0–1.0, default: 1.0)
+--
+-- Example:
+--   ## My Slide {background-image="img/hero.jpg" background-size="cover"}
+--
+-- Title slide (frontmatter):
+--   title-slide-attributes:
+--     data-background-image: img/hero.jpg
+--     data-background-size: cover
+--     data-background-opacity: "0.5"      (optional)
+
+local function is_opaque(opacity)
+  return opacity == nil or opacity == "" or opacity == "1" or opacity == "1.0"
+end
+
+-- Build the LaTeX command that sets the background for one frame.
+local function set_background_latex(image, size, opacity)
+  size = size or "cover"
+  local img_opts
+  if size == "contain" then
+    img_opts = "width=\\paperwidth,height=\\paperheight,keepaspectratio"
+  else
+    img_opts = "width=\\paperwidth,height=\\paperheight"
+  end
+
+  if is_opaque(opacity) then
+    return string.format(
+      "\\usebackgroundtemplate{\\includegraphics[%s]{%s}}",
+      img_opts, image
+    )
+  else
+    -- Opacity requires TikZ overlay
+    return string.format(
+      "\\setbeamertemplate{background}{%%\n" ..
+      "  \\begin{tikzpicture}[remember picture,overlay]\n" ..
+      "    \\node[opacity=%s] at (current page.center)\n" ..
+      "      {\\includegraphics[%s]{%s}};\n" ..
+      "  \\end{tikzpicture}%%\n" ..
+      "}",
+      opacity, img_opts, image
+    )
+  end
+end
+
+-- Build the LaTeX command that clears the background after a frame.
+local function reset_background_latex(used_tikz)
+  if used_tikz then
+    return "\\setbeamertemplate{background}{}"
+  else
+    return "\\usebackgroundtemplate{}"
+  end
+end
+
+-- Prepend an item to a MetaList (or create one from a single value).
+local function prepend_header_include(meta, raw_latex)
+  local item = pandoc.MetaBlocks({ pandoc.RawBlock("latex", raw_latex) })
+  local hi = meta["header-includes"]
+  if hi == nil then
+    meta["header-includes"] = pandoc.MetaList({ item })
+  elseif hi.t == "MetaList" then
+    table.insert(hi, 1, item)
+  else
+    meta["header-includes"] = pandoc.MetaList({ item, hi })
+  end
+end
+
+function Pandoc(doc)
+  if FORMAT ~= "beamer" then return nil end
+
+  local new_blocks = {}
+  local in_bg      = false   -- currently inside a slide with a custom background
+  local bg_tikz    = false   -- that background uses TikZ (opacity)
+  local needs_tikz = false   -- any opacity was requested anywhere in the doc
+
+  for _, block in ipairs(doc.blocks) do
+    -- A new section (level 1) or slide (level 2) ends any active background.
+    if block.t == "Header" and (block.level == 1 or block.level == 2) then
+      if in_bg then
+        table.insert(new_blocks, pandoc.RawBlock("latex", reset_background_latex(bg_tikz)))
+        in_bg   = false
+        bg_tikz = false
+      end
+
+      -- Check whether this header carries a background-image attribute.
+      local bg      = block.attr.attributes["background-image"]
+      local size    = block.attr.attributes["background-size"]
+      local opacity = block.attr.attributes["background-opacity"]
+
+      if bg then
+        local use_tikz = not is_opaque(opacity)
+        if use_tikz then needs_tikz = true end
+        table.insert(new_blocks, pandoc.RawBlock("latex",
+          set_background_latex(bg, size, opacity)))
+        in_bg   = true
+        bg_tikz = use_tikz
+
+        -- Strip background attrs so Beamer doesn't trip on unknown keys.
+        block.attr.attributes["background-image"]   = nil
+        block.attr.attributes["background-size"]    = nil
+        block.attr.attributes["background-opacity"] = nil
+      end
+    end
+
+    table.insert(new_blocks, block)
+  end
+
+  -- Close any background that was still open at the end of the document.
+  if in_bg then
+    table.insert(new_blocks, pandoc.RawBlock("latex", reset_background_latex(bg_tikz)))
+  end
+
+  -- -------------------------------------------------------------------------
+  -- Title slide: honour data-background-image from title-slide-attributes.
+  -- -------------------------------------------------------------------------
+  local meta = doc.meta
+  local tsa  = meta["title-slide-attributes"]
+  if tsa then
+    local bg      = tsa["data-background-image"]
+    local size    = tsa["data-background-size"]
+    local opacity = tsa["data-background-opacity"]
+
+    if bg then
+      bg      = pandoc.utils.stringify(bg)
+      size    = size    and pandoc.utils.stringify(size)    or "cover"
+      opacity = opacity and pandoc.utils.stringify(opacity) or nil
+
+      local use_tikz = not is_opaque(opacity)
+      if use_tikz then needs_tikz = true end
+
+      -- Set the background before the title frame, then reset it inside the
+      -- title page template (runs after \titlepage, before \end{frame}).
+      local latex = set_background_latex(bg, size, opacity) .. "\n" ..
+        "\\addtobeamertemplate{title page}{}{" ..
+        reset_background_latex(use_tikz) .. "}"
+
+      prepend_header_include(meta, latex)
+    end
+  end
+
+  -- -------------------------------------------------------------------------
+  -- Load TikZ if any opacity was requested.
+  -- -------------------------------------------------------------------------
+  if needs_tikz then
+    prepend_header_include(meta, "\\usepackage{tikz}")
+  end
+
+  return pandoc.Pandoc(new_blocks, meta)
+end

--- a/test-beamer-bg.tex
+++ b/test-beamer-bg.tex
@@ -1,0 +1,136 @@
+\documentclass[aspectratio=169]{beamer}
+\usetheme{metropolis}
+
+% ── etoolbox approach: BeforeBeginEnvironment + global flag ──────────────────
+\usepackage{etoolbox}
+\usepackage{tikz}
+\usepackage{graphicx}
+
+\newif\ifbgpending    % true  → next frame should get a background
+\newif\ifbgopaque     % true  → use \usebackgroundtemplate; false → TikZ opacity
+\global\bgpendingfalse
+\global\bgopaquetrue
+\gdef\bgpendingimage{}
+\gdef\bgpendingsize{cover}
+\gdef\bgpendingopc{1}
+
+% This hook fires at the true outer level, before \begin{frame} opens any
+% group, so assignments here are effectively global even without \global.
+\BeforeBeginEnvironment{frame}{%
+  \ifbgpending
+    % ── decide cover vs contain ──────────────────────────────────────────────
+    \def\tmpsize{\bgpendingsize}%
+    \def\tmpcontain{contain}%
+    \ifbgopaque
+      % ── opaque: \usebackgroundtemplate ─────────────────────────────────────
+      \ifx\tmpsize\tmpcontain
+        \usebackgroundtemplate{%
+          \includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio]%
+            {\bgpendingimage}}%
+      \else
+        \usebackgroundtemplate{%
+          \includegraphics[width=\paperwidth,height=\paperheight]%
+            {\bgpendingimage}}%
+      \fi
+    \else
+      % ── transparent: TikZ node with opacity ────────────────────────────────
+      \ifx\tmpsize\tmpcontain
+        \setbeamertemplate{background}{%
+          \begin{tikzpicture}[remember picture,overlay]
+            \node[opacity=\bgpendingopc] at (current page.center)
+              {\includegraphics[width=\paperwidth,height=\paperheight,
+                                keepaspectratio]{\bgpendingimage}};
+          \end{tikzpicture}}%
+      \else
+        \setbeamertemplate{background}{%
+          \begin{tikzpicture}[remember picture,overlay]
+            \node[opacity=\bgpendingopc] at (current page.center)
+              {\includegraphics[width=\paperwidth,height=\paperheight]%
+                {\bgpendingimage}};
+          \end{tikzpicture}}%
+      \fi
+    \fi
+    % clear the flag so the NEXT frame reverts to no background
+    \global\bgpendingfalse
+    \global\bgopaquetrue
+  \else
+    % no background requested → reset both template slots
+    \usebackgroundtemplate{}%
+    \setbeamertemplate{background}{}%
+  \fi
+}
+% ─────────────────────────────────────────────────────────────────────────────
+
+\title{BeforeBeginEnvironment Test}
+\author{Test}
+\date{}
+
+\begin{document}
+
+% ── Slide 1: title (plain, NO background) ───────────────────────────────────
+\begin{frame}[plain,noframenumbering]
+  \titlepage
+\end{frame}
+
+% ── Slide 2: plain text, NO background ──────────────────────────────────────
+\begin{frame}
+  \frametitle{Slide 2 — No Background}
+  This slide should have the default (empty) background.
+\end{frame}
+
+% set flag for slide 3 only
+\gdef\bgpendingimage{/home/user/pandoc-course-template/lectures/img/sullivans.jpg}
+\gdef\bgpendingsize{cover}
+\global\bgopaquetrue
+\global\bgpendingtrue
+
+% ── Slide 3: WITH background (opaque, cover) ─────────────────────────────────
+\begin{frame}
+  \frametitle{Slide 3 — WITH Background (opaque)}
+  The sullivans.jpg image should fill this slide.
+\end{frame}
+
+% ── Slide 4: NO background (flag was cleared by hook) ───────────────────────
+\begin{frame}
+  \frametitle{Slide 4 — No Background Again}
+  Background must be gone. If you still see it, the reset failed.
+\end{frame}
+
+% set flag for slide 5 (TikZ opacity)
+\gdef\bgpendingimage{/home/user/pandoc-course-template/lectures/img/sullivans.jpg}
+\gdef\bgpendingsize{cover}
+\gdef\bgpendingopc{0.35}
+\global\bgopaquefalse
+\global\bgpendingtrue
+
+% ── Slide 5: WITH background (semi-transparent via TikZ) ────────────────────
+\begin{frame}
+  \frametitle{Slide 5 — Background at 35\% opacity}
+  The image should appear faintly behind this text.
+\end{frame}
+
+% ── Slide 6: NO background ──────────────────────────────────────────────────
+\begin{frame}
+  \frametitle{Slide 6 — No Background After Opacity Slide}
+  Background must be gone again.
+\end{frame}
+
+% set flag for slide 7 (contain sizing)
+\gdef\bgpendingimage{/home/user/pandoc-course-template/lectures/img/sullivans.jpg}
+\gdef\bgpendingsize{contain}
+\global\bgopaquetrue
+\global\bgpendingtrue
+
+% ── Slide 7: WITH background (contain sizing) ───────────────────────────────
+\begin{frame}
+  \frametitle{Slide 7 — Background (contain)}
+  Image should be letterboxed / pillarboxed with bars visible.
+\end{frame}
+
+% ── Slide 8: NO background ──────────────────────────────────────────────────
+\begin{frame}
+  \frametitle{Slide 8 — Plain Again}
+  Clean slide after contain-sized background.
+\end{frame}
+
+\end{document}


### PR DESCRIPTION
## Problem

The double-`\aftergroup` approach fails because Beamer's `\endframe` does
`\egroup\begingroup`, so any scheduled reset fires inside the inner
`\begingroup` rather than at the true outer TeX level.

## Approach: `\BeforeBeginEnvironment{frame}` + global flag

`\BeforeBeginEnvironment{frame}` (etoolbox) fires *before* `\begin{frame}`
opens any group — at the true outer TeX level.

1. A global flag (`\ifbgpending`) and macros (`\bgpendingimage`,
   `\bgpendingsize`, `\bgpendingopc`) are armed just before the target slide.
2. The hook checks the flag on **every** `\begin{frame}`:
   - Flag set → apply background (opaque via `\usebackgroundtemplate`,
     semi-transparent via TikZ node), then clear flag.
   - Flag not set → reset both template slots; background never bleeds forward.
3. No explicit "after" reset block needed — the hook resets on the very next
   frame automatically.

### Proof of concept (`test-beamer-bg.tex`)

8 slides: plain → plain → BG opaque → plain → BG 35% opacity → plain →
BG contain → plain.

`pdfimages -list` confirms images on exactly pages **3, 5, 7** — none on
1, 2, 4, 6, 8. ✅

### Flag placement subtlety

The flag-setter raw block lands inside the *previous* frame's
`\begin{block}` (because a `###` sub-heading precedes the `##` background
slide). This is fine: `\gdef` and `\global` are **unconditionally global**
in TeX and escape all group nesting.

## Title slide & section separators — hybrid approach

The pandoc beamer template uses `\frame{\titlepage}` and
`\frame{\sectionpage}` — neither triggers `\BeforeBeginEnvironment{frame}`.

**Title slide:** `\usebackgroundtemplate` set directly in the preamble;
`\AddToHookNext{shipout/after}` schedules a one-shot reset after the title
page ships out (avoids the spurious blank `\begin{frame}` that a body raw
block would create).

**Known bug:** The section-separator page immediately after the title still
inherits the background — the `shipout/after` reset fires too late relative
to when beamer captures the background template for that frame.
