### PR TITLE
Add title-slide background image for Beamer PDF

### DIFF
--- a/filters/beamer-background.lua
+++ b/filters/beamer-background.lua
@@ -143,12 +143,24 @@ local PREAMBLE_HOOK = [[
   \fi
 }]]
 
--- Generate title-slide background LaTeX using \AddToHookNext{shipout/background}.
--- This one-shot hook fires exactly once for the first page shipped (the title page)
--- and then removes itself automatically — no bleed onto section separators or content.
--- \AtBeginDocument wrapping ensures tikz is loaded before the hook body executes.
+-- Generate title-slide background LaTeX.
+--
+-- Strategy (empirically proven; shipout hooks don't work with beamer):
+--   \AtBeginDocument sets \setbeamertemplate{background} to the image (same
+--   mechanism as per-slide backgrounds) and arms \bgactivetrue so the first
+--   \begin{frame} resets it via the existing \BeforeBeginEnvironment hook.
+--
+--   Section-separator pages (\frame{\sectionpage}) don't trigger
+--   \BeforeBeginEnvironment{frame}, so we use \makeatletter to prepend a
+--   reset to beamer's internal \beamer@atbeginsection macro — this fires
+--   before \frame{\sectionpage} is called, clearing the template in time.
 local function make_title_bg_latex(image, size, opacity)
   size = size or "cover"
+
+  local node_opts = ""
+  if not is_opaque(opacity) then
+    node_opts = string.format("[opacity=%s]", opacity)
+  end
 
   local include_opts
   if size == "contain" then
@@ -157,20 +169,22 @@ local function make_title_bg_latex(image, size, opacity)
     include_opts = "width=\\paperwidth,height=\\paperheight"
   end
 
-  local node_opts = ""
-  if not is_opaque(opacity) then
-    node_opts = string.format("[opacity=%s]", opacity)
-  end
-
   return string.format([[
 \AtBeginDocument{%%
-  \AddToHookNext{shipout/background}{%%
+  \setbeamertemplate{background}{%%
     \begin{tikzpicture}[remember picture,overlay]
       \node%s at (current page.center)
         {\includegraphics[%s]{%s}};
     \end{tikzpicture}%%
   }%%
-}]], node_opts, include_opts, image)
+  \global\bgactivetrue
+}
+\makeatletter
+\preto\beamer@atbeginsection{%%
+  \setbeamertemplate{background}{}%%
+  \global\bgactivefalse
+}
+\makeatother]], node_opts, include_opts, image)
 end
 
 -- Prepend an item to a MetaList (or create one from a single value).
@@ -215,16 +229,15 @@ function Pandoc(doc)
     table.insert(new_blocks, block)
   end
 
-  -- Install preamble hook only when at least one content slide needs it.
-  if has_content_bg then
-    prepend_header_include(doc.meta, PREAMBLE_HOOK)
-  end
-
   -- Handle title-slide background from frontmatter title-slide-attributes.
   -- \frame{\titlepage} does not trigger \BeforeBeginEnvironment{frame}, so we
-  -- use \AddToHookNext{shipout/background} — a one-shot hook that fires for
-  -- exactly one page (the title) then removes itself.
+  -- set \setbeamertemplate{background} in \AtBeginDocument and rely on:
+  --   • \preto\beamer@atbeginsection — resets before section separator pages
+  --   • \BeforeBeginEnvironment{frame} + \bgactivetrue — resets on first content frame
   local title_attrs = doc.meta["title-slide-attributes"]
+  local has_title_bg = false
+  local title_bg_latex = nil
+
   if title_attrs then
     local title_bg      = nil
     local title_size    = "cover"
@@ -242,13 +255,20 @@ function Pandoc(doc)
     end
 
     if title_bg then
-      title_bg = resolve_image_path(title_bg)
-      -- Ensure tikz is available when PREAMBLE_HOOK is not injected.
-      if not has_content_bg then
-        prepend_header_include(doc.meta, "\\usepackage{tikz}")
-      end
-      prepend_header_include(doc.meta, make_title_bg_latex(title_bg, title_size, title_opacity))
+      has_title_bg = true
+      title_bg_latex = make_title_bg_latex(
+        resolve_image_path(title_bg), title_size, title_opacity)
     end
+  end
+
+  -- PREAMBLE_HOOK provides the flags (\ifbgactive etc.) and the
+  -- \BeforeBeginEnvironment{frame} reset used by both per-slide and title bgs.
+  if has_content_bg or has_title_bg then
+    prepend_header_include(doc.meta, PREAMBLE_HOOK)
+  end
+
+  if has_title_bg then
+    prepend_header_include(doc.meta, title_bg_latex)
   end
 
   return pandoc.Pandoc(new_blocks, doc.meta)

--- a/filters/beamer-background.lua
+++ b/filters/beamer-background.lua
@@ -1,6 +1,6 @@
 -- beamer-background.lua
 --
--- Adds per-slide background image support for Beamer PDF output.
+-- Adds per-slide and title-slide background image support for Beamer PDF output.
 -- Reads the same attributes used by reveal.js, so slides work across
 -- both output formats without any changes to the Markdown source.
 --
@@ -9,12 +9,14 @@
 --   background-size="cover"               (optional; "cover" or "contain", default: cover)
 --   background-opacity="0.4"              (optional; 0.0–1.0, default: 1.0)
 --
+-- Title slide background is read from the frontmatter:
+--   title-slide-attributes:
+--     data-background-image: img/foo.jpg
+--     data-background-size: cover         (optional)
+--     data-background-opacity: "0.4"      (optional)
+--
 -- Example:
 --   ## My Slide {background-image="img/hero.jpg" background-size="cover"}
---
--- Note: title-slide backgrounds (title-slide-attributes) are not handled
--- here; \frame{\titlepage} does not trigger \BeforeBeginEnvironment{frame}
--- and requires separate treatment.
 --
 -- ── Strategy ─────────────────────────────────────────────────────────────────
 -- Content slides always use \begin{frame}, so \BeforeBeginEnvironment{frame}
@@ -141,6 +143,36 @@ local PREAMBLE_HOOK = [[
   \fi
 }]]
 
+-- Generate title-slide background LaTeX using \AddToHookNext{shipout/background}.
+-- This one-shot hook fires exactly once for the first page shipped (the title page)
+-- and then removes itself automatically — no bleed onto section separators or content.
+-- \AtBeginDocument wrapping ensures tikz is loaded before the hook body executes.
+local function make_title_bg_latex(image, size, opacity)
+  size = size or "cover"
+
+  local include_opts
+  if size == "contain" then
+    include_opts = "width=\\paperwidth,height=\\paperheight,keepaspectratio"
+  else
+    include_opts = "width=\\paperwidth,height=\\paperheight"
+  end
+
+  local node_opts = ""
+  if not is_opaque(opacity) then
+    node_opts = string.format("[opacity=%s]", opacity)
+  end
+
+  return string.format([[
+\AtBeginDocument{%%
+  \AddToHookNext{shipout/background}{%%
+    \begin{tikzpicture}[remember picture,overlay]
+      \node%s at (current page.center)
+        {\includegraphics[%s]{%s}};
+    \end{tikzpicture}%%
+  }%%
+}]], node_opts, include_opts, image)
+end
+
 -- Prepend an item to a MetaList (or create one from a single value).
 local function prepend_header_include(meta, raw_latex)
   local item = pandoc.MetaBlocks({ pandoc.RawBlock("latex", raw_latex) })
@@ -186,6 +218,37 @@ function Pandoc(doc)
   -- Install preamble hook only when at least one content slide needs it.
   if has_content_bg then
     prepend_header_include(doc.meta, PREAMBLE_HOOK)
+  end
+
+  -- Handle title-slide background from frontmatter title-slide-attributes.
+  -- \frame{\titlepage} does not trigger \BeforeBeginEnvironment{frame}, so we
+  -- use \AddToHookNext{shipout/background} — a one-shot hook that fires for
+  -- exactly one page (the title) then removes itself.
+  local title_attrs = doc.meta["title-slide-attributes"]
+  if title_attrs then
+    local title_bg      = nil
+    local title_size    = "cover"
+    local title_opacity = nil
+
+    for k, v in pairs(title_attrs) do
+      local val = pandoc.utils.stringify(v)
+      if k == "data-background-image" then
+        title_bg = val
+      elseif k == "data-background-size" then
+        title_size = val
+      elseif k == "data-background-opacity" then
+        title_opacity = val
+      end
+    end
+
+    if title_bg then
+      title_bg = resolve_image_path(title_bg)
+      -- Ensure tikz is available when PREAMBLE_HOOK is not injected.
+      if not has_content_bg then
+        prepend_header_include(doc.meta, "\\usepackage{tikz}")
+      end
+      prepend_header_include(doc.meta, make_title_bg_latex(title_bg, title_size, title_opacity))
+    end
   end
 
   return pandoc.Pandoc(new_blocks, doc.meta)


### PR DESCRIPTION
## Summary

- Reads `data-background-image` (and `data-background-size`, `data-background-opacity`) from the frontmatter `title-slide-attributes` block — the same field already used by reveal.js
- Uses `\setbeamertemplate{background}` set in `\AtBeginDocument` (the same mechanism as per-slide backgrounds, proven to work)
- Resets via `\preto\beamer@atbeginsection` before section separator pages, and via the existing `\BeforeBeginEnvironment{frame}` hook (armed with `\bgactivetrue`) for the first content frame

## Why this approach (lessons from iteration)

Several approaches were tried and ruled out:
- `\AddToHookNext{shipout/background}` with `\put` or TikZ — beamer bypasses LaTeX's shipout hooks entirely
- `\addtobeamertemplate{background/title page}{}{\reset}` — beamer saves/restores the background template around each frame, so resets inside the frame have no effect
- `\AtBeginSection{\reset}` — the pandoc template's `\AtBeginSection` is registered before `header-includes`, so this fires after the section page renders

The working approach uses `\makeatletter\preto\beamer@atbeginsection` to prepend the reset directly to beamer's internal section hook, which fires before `\frame{\sectionpage}`.

## Verified locally

- Page 1 (title): dalmeny.jpg background ✓
- Page 2 (section separator): plain dark ✓ — no bleed
- Page 5 (explicit `background-image=` slide): sullivans creek background ✓
- All other slides: plain dark ✓

## Test plan

- [ ] CI build passes (`make public` in Docker)
- [ ] Title slide shows background image
- [ ] Section separator has no background
- [ ] Per-slide `background-image=` attribute still works
- [ ] Slides without background are unaffected

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)