### PR TITLE
Fix CI: bump to TeX Live 2026 image and self-update tlmgr

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     container:
-      image: pandoc/latex:3.9
+      image: pandoc/latex:3.10.0.0-alpine
       options: --user root
 
     steps:
@@ -57,6 +57,12 @@ jobs:
 
       - name: Install Latex Dependencies
         run: |
+          # This image ships TeX Live 2026, matching the current live CTAN
+          # release. tlmgr still refuses to install until its own revision
+          # matches the (moving) live tlnet repo, so self-update first — this
+          # is allowed now that image and repo are the same release year.
+          # If the live CTAN later rolls over to 2027, bump the image tag to a
+          # pandoc/latex build carrying that year's TeX Live to keep them aligned.
           tlmgr update --self
           tlmgr install libertine \
                   sourcecodepro \

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
 
     container:
-      image: pandoc/latex:3.9
+      image: pandoc/latex:3.10.0.0-alpine
       options: --user root
 
     steps:
@@ -27,6 +27,12 @@ jobs:
 
       - name: Install Latex Dependencies
         run: |
+          # This image ships TeX Live 2026, matching the current live CTAN
+          # release. tlmgr still refuses to install until its own revision
+          # matches the (moving) live tlnet repo, so self-update first — this
+          # is allowed now that image and repo are the same release year.
+          # If the live CTAN later rolls over to 2027, bump the image tag to a
+          # pandoc/latex build carrying that year's TeX Live to keep them aligned.
           tlmgr update --self
           tlmgr install libertine \
                   sourcecodepro \


### PR DESCRIPTION
## Problem

The `pandoc/latex:3.9` container ships TeX Live 2025, but the live CTAN repo has rolled over to 2026. `tlmgr update --self` fails the cross-release guard, so both the `deploy` and `pr-build` jobs error out before any LaTeX package installs.

## Fix

Bump the `pandoc/latex` image to a TL2026 build (`3.10.0.0-alpine`) in both `deploy.yml` and `pr-build.yml` so the image and the live tlnet repo are the same release year. `tlmgr update --self` (already present) is then permitted, and the subsequent `tlmgr install` proceeds. Added a comment explaining the alignment and how to handle a future 2027 rollover.

## Verification

Verified end-to-end downstream in [`cpmpercussion/soco-tutor-training`](https://github.com/cpmpercussion/soco-tutor-training), which uses this template: reproducing the exact CI steps in the new container (linux/amd64), `tlmgr` self-update + install succeed and the full build completes cleanly. Opening as a draft so the repo's own `pr-build` workflow can confirm on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)