### PR TITLE
Fix beamer backgrounds landing on the wrong slide

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ on:
       - 'workshops/**'
       - 'resources/**'
       - 'css/**'
+      - 'filters/**'
       - 'Makefile'
       - '_config.toml'
       - 'references.bib'
@@ -48,9 +49,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./build
-          key: build-v1-${{ hashFiles('Makefile', '_config.toml', 'references.bib', 'apa.csl') }}-${{ github.sha }}
+          # filters/ is in the key because a filter change alters the PDFs
+          # without touching any .md. git-restore-mtime would leave the cached
+          # PDFs looking newer than their sources, and make would skip them.
+          key: build-v1-${{ hashFiles('Makefile', '_config.toml', 'references.bib', 'apa.csl', 'filters/**') }}-${{ github.sha }}
           restore-keys: |
-            build-v1-${{ hashFiles('Makefile', '_config.toml', 'references.bib', 'apa.csl') }}-
+            build-v1-${{ hashFiles('Makefile', '_config.toml', 'references.bib', 'apa.csl', 'filters/**') }}-
 
       - name: Restore file modification times (requires git and python3)
         uses: chetan/git-restore-mtime-action@v2
@@ -72,6 +76,7 @@ jobs:
                   hanging \
                   beamer \
                   beamertheme-metropolis \
+                  pgf \
                   pgfopts \
                   beamercolorthemeowl \
                   noto \

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -42,6 +42,7 @@ jobs:
                   hanging \
                   beamer \
                   beamertheme-metropolis \
+                  pgf \
                   pgfopts \
                   beamercolorthemeowl \
                   noto \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ CSS for reveal.js is compiled from SCSS:
 sass css/reveal_dark.scss build/lectures/reveal_dark.css
 ```
 
-Beamer PDFs are built with `lualatex` and require these fonts: Linux Libertine O, Noto Sans, Noto Color Emoji. Presentations use the metropolis theme with owl color scheme at 16:9 aspect ratio.
+Beamer PDFs are built with `lualatex` and require these fonts: Linux Libertine O, Noto Sans, Noto Color Emoji. Presentations use the metropolis theme with owl color scheme at 16:9 aspect ratio. They also require `pgf`/`tikz` and `etoolbox` (both are beamer dependencies, so a standard beamer install already has them) for slide background images — see `filters/beamer-background.lua`.
 
 ## Content Structure
 
@@ -38,6 +38,7 @@ Beamer PDFs are built with `lualatex` and require these fonts: Linux Libertine O
 - `assessments/` — Assessment specs (`.md`), built to HTML + PDF
 - `workshops/` — Tutorial/workshop activities (`.md`), built to HTML only
 - `resources/` — Supplementary resources (`.md`), built to HTML only
+- `filters/` — pandoc Lua filters (`beamer-background.lua`), applied via `BEAMER_OPTS`
 - Each content directory has its own `img/` subdirectory — images **cannot be shared across directories**
 - `references.bib` — Shared BibTeX references (APA citation style via `apa.csl`)
 - `_config.toml` — Course metadata (title, institution, author, year) used by `generate_index.py`
@@ -49,7 +50,12 @@ Lecture slides use pandoc's Markdown with `--slide-level 2`:
 - `##` headings create regular slides
 - `###` and below are content within a slide
 
-Lecture frontmatter includes title-slide background images:
+Reveal.js-specific syntax is supported (e.g., `{.columns}`, `{.column width="50%"}`, `background-image=` on headings).
+
+### Slide Background Images
+
+Backgrounds render in **both** reveal.js and Beamer PDF output from the same source. Title slide, from the frontmatter:
+
 ```yaml
 ---
 title: "Slide Title"
@@ -60,7 +66,17 @@ title-slide-attributes:
 ---
 ```
 
-Reveal.js-specific syntax is supported (e.g., `{.columns}`, `{.column width="50%"}`, `background-image=` on headings).
+Any `#` (section) or `##` (slide) heading, via attributes:
+
+```markdown
+## My Slide {background-image="img/hero.jpg" background-size="cover" background-opacity="0.4"}
+```
+
+`background-size` is `cover` (default, fills the slide and crops the overflow) or `contain` (whole image, letterboxed). `background-opacity` takes 0.0–1.0 and is useful when heading text would otherwise sit on a busy photo.
+
+The PDF side is `filters/beamer-background.lua`, wired in through `BEAMER_OPTS`. Beamer has no native equivalent of these attributes, so without the filter the backgrounds are silently dropped from the PDFs while still appearing in the HTML. Read the strategy comment at the top of the filter before changing it: the mechanism depends on *where* pandoc places raw blocks relative to `\begin{frame}`, and the obvious implementations fail in ways that are easy to miss — a background landing on the wrong slide, or an extra blank slide.
+
+One known gap: a background on an `{.unnumbered}` `#` heading is skipped (with a warning on stderr), because section pages are keyed by section number and unnumbered sections don't advance the counter.
 
 Citations use pandoc format: `[@bibtex-key]`, `[@bibtex-key, p26]`. References go in `references.bib`; referencing style is APA (`apa.csl`).
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ ASSESSMENTS_DIR = assessments
 WORKSHOPS_DIR   = workshops
 RESOURCES_DIR   = resources
 TEMPLATES_DIR   = templates
+FILTERS_DIR     = filters
 OUTPUT_DIR      = build
 IMAGE_DIR       = img
 
@@ -58,6 +59,11 @@ REVEAL_OPTS = -t revealjs \
               -V slideNumber=true \
               --css reveal_dark.css
 
+# Beamer has no native equivalent of reveal.js's background-image attributes, so
+# a Lua filter translates them into TikZ background overlays. Without it the
+# backgrounds are silently dropped from the PDFs.
+BEAMER_FILTER = $(FILTERS_DIR)/beamer-background.lua
+
 BEAMER_OPTS = -t beamer \
               -V aspectratio=169 \
               -V theme=metropolis \
@@ -65,7 +71,7 @@ BEAMER_OPTS = -t beamer \
               --pdf-engine=lualatex \
               -V mainfont="Noto Sans" \
               -V mainfontfallback="NotoColorEmoji:mode=harf" \
-              --lua-filter=filters/beamer-background.lua
+              --lua-filter=$(BEAMER_FILTER)
 
 # --pdf-engine=xelatex
 
@@ -118,7 +124,7 @@ $(LECTURES_OUT)/%.html: $(LECTURES_DIR)/%.md
 .PHONY: beamer
 beamer: $(LECTURES_OUT) $(BEAMER_PDFS)
 
-$(LECTURES_OUT)/%.pdf: $(LECTURES_DIR)/%.md
+$(LECTURES_OUT)/%.pdf: $(LECTURES_DIR)/%.md $(BEAMER_FILTER)
 	$(PANDOC) $(PANDOC_COMMON_OPTS) $(BEAMER_OPTS) $< -o $@
 
 # =============================================================================

--- a/filters/beamer-background.lua
+++ b/filters/beamer-background.lua
@@ -1,15 +1,16 @@
 -- beamer-background.lua
 --
--- Adds per-slide and title-slide background image support for Beamer PDF output.
--- Reads the same attributes used by reveal.js, so slides work across
--- both output formats without any changes to the Markdown source.
+-- Adds per-slide, section-page and title-slide background image support for
+-- Beamer PDF output. It reads the same attributes reveal.js already uses, so a
+-- deck gets the same backgrounds in both output formats with no change to the
+-- Markdown source.
 --
--- Supported attributes on ## headings:
---   background-image="img/foo.jpg"        (required)
+-- Supported attributes on `#` and `##` headings:
+--   background-image="img/foo.jpg"        (required; data-background-image also accepted)
 --   background-size="cover"               (optional; "cover" or "contain", default: cover)
 --   background-opacity="0.4"              (optional; 0.0–1.0, default: 1.0)
 --
--- Title slide background is read from the frontmatter:
+-- Title slide background comes from the frontmatter:
 --   title-slide-attributes:
 --     data-background-image: img/foo.jpg
 --     data-background-size: cover         (optional)
@@ -19,25 +20,47 @@
 --   ## My Slide {background-image="img/hero.jpg" background-size="cover"}
 --
 -- ── Strategy ─────────────────────────────────────────────────────────────────
--- Content slides always use \begin{frame}, so \BeforeBeginEnvironment{frame}
--- fires reliably at the true outer TeX level before any group opens.
+-- Beamer paints \setbeamertemplate{background} beneath everything else on the
+-- page, so that is the layer we use. The theme's own `background canvas` is
+-- never touched, which leaves the metropolis/owl colours intact.
 --
--- A raw LaTeX block is inserted just before each background heading to arm a
--- global flag (\ifbgpending).  The hook reads the flag and installs a TikZ-
--- based \setbeamertemplate{background} overlay.  Using the overlay layer
--- (never \usebackgroundtemplate / background canvas) means the beamer theme's
--- own canvas colour is never disturbed.
+-- The template is installed exactly once, in the preamble, as an indirection
+-- through a single macro:
 --
--- A second flag (\ifbgactive) tracks whether a background is currently applied
--- so that plain frames only receive a reset call on the transition from a
--- background slide, leaving all other frames' default styling completely intact.
+--     \setbeamertemplate{background}{\bgcurrent}
+--
+-- \bgcurrent is expanded at *shipout*, not where it is set, and a beamer frame
+-- ships out at its \end{frame} — after its entire body has been read. So a
+-- frame renders whatever \bgcurrent holds at the end of its body:
+--
+--   * \BeforeBeginEnvironment{frame} clears \bgcurrent, so every frame starts
+--     out with no background image.
+--   * A frame that wants one carries \gdef\bgcurrent{...} as the first block of
+--     its own body. Nothing later can overwrite that before the frame ships,
+--     and the assignment is global so the frame group cannot swallow it.
+--
+-- Setting \bgcurrent from *inside* the body, rather than arming a flag before
+-- the frame, is what makes this reliable. Pandoc — not this filter — decides
+-- where frames begin and end, and a raw block emitted before a heading does not
+-- land where you would hope: it is absorbed into the *previous* frame's body,
+-- or, at the very start of the document, becomes a frame of its own and shows
+-- up in the PDF as a blank slide.
+--
+-- \frame{\titlepage} and \frame{\sectionpage} are the command form of the
+-- environment, so they never trip \BeforeBeginEnvironment{frame}, and neither
+-- has a body this filter can write into. They are handled separately:
+--   * the title background is set in \AtBeginDocument and survives until the
+--     first real \begin{frame} clears it;
+--   * section backgrounds are stored in the preamble under the section number
+--     and picked up by a patched \beamer@atbeginsection, which keeps them out
+--     of the block stream entirely.
 
 local function is_opaque(opacity)
   return opacity == nil or opacity == "" or opacity == "1" or opacity == "1.0"
 end
 
--- Resolve an image path to absolute so lualatex can find it regardless of
--- the temp directory it runs from.  Relative paths are resolved against the
+-- Resolve an image path to absolute so lualatex can find it regardless of the
+-- temp directory it runs from. Relative paths are resolved against the
 -- directory containing the first input file.
 local function resolve_image_path(image)
   if pandoc.path.is_absolute(image) then return image end
@@ -49,142 +72,82 @@ local function resolve_image_path(image)
   return pandoc.path.join({base, image})
 end
 
--- Arm the global flag just before a \begin{frame}.
--- Even if this raw block lands inside the previous frame's body (e.g. inside
--- a block environment), \gdef/\global assignments are unconditionally global
--- in TeX and will be visible when the hook fires for the next \begin{frame}.
-local function set_pending_latex(image, size, opacity)
-  size = size or "cover"
-  local lines = {
-    string.format("\\gdef\\bgpendingimage{%s}", image),
-    string.format("\\gdef\\bgpendingsize{%s}",  size),
-  }
-  if is_opaque(opacity) then
-    table.insert(lines, "\\global\\bgopaquetrue")
-  else
-    table.insert(lines, string.format("\\gdef\\bgpendingopc{%s}", opacity))
-    table.insert(lines, "\\global\\bgopaquefalse")
-  end
-  table.insert(lines, "\\global\\bgpendingtrue")
-  return table.concat(lines, "\n")
-end
-
--- Preamble block: declares flags/macros and installs the hook.
+-- Preamble: the fitting macros, the one-time template install, and the hooks
+-- that clear or supply \bgcurrent for each kind of frame.
 --
--- All image backgrounds are rendered as a TikZ \setbeamertemplate{background}
--- overlay so that the beamer background canvas (theme colours) is never
--- touched.  Conditionals are evaluated inside the hook (at outer TeX level,
--- before the frame group opens) so the correct template variant is installed
--- before beamer captures it for the frame.
---
--- \ifbgactive ensures plain frames only issue a \setbeamertemplate{background}{}
--- reset on the single frame that follows a background slide, and are otherwise
--- left untouched.
-local PREAMBLE_HOOK = [[
+-- \bgcoverimage reproduces CSS/reveal.js `cover`: scale the image so it fills
+-- the slide with no gap and let the excess run off the edge (the surrounding
+-- \clip discards it). Scaling to \paperwidth and measuring the result answers
+-- "which dimension is the constraining one?" without any ratio arithmetic, and
+-- the measured box is reused when width turns out to be the answer.
+local PREAMBLE = [[
 \usepackage{etoolbox}
 \usepackage{tikz}
-\newif\ifbgpending  % true → next \begin{frame} should receive a background image
-\newif\ifbgopaque   % true → opaque (no alpha); false → semi-transparent TikZ node
-\newif\ifbgactive   % true → a background is applied; reset on next plain frame
-\global\bgpendingfalse
-\global\bgopaquetrue
-\global\bgactivefalse
-\gdef\bgpendingimage{}
-\gdef\bgpendingsize{cover}
-\gdef\bgpendingopc{1}
-% Hook fires at the true outer TeX level, before \begin{frame} opens any group.
-\BeforeBeginEnvironment{frame}{%
-  \ifbgpending
-    \def\tmpbgsize{\bgpendingsize}%
-    \def\tmpcontain{contain}%
-    \ifbgopaque
-      \ifx\tmpbgsize\tmpcontain
-        \setbeamertemplate{background}{%
-          \begin{tikzpicture}[remember picture,overlay]
-            \node at (current page.center)
-              {\includegraphics[width=\paperwidth,height=\paperheight,
-                                keepaspectratio]{\bgpendingimage}};
-          \end{tikzpicture}}%
-      \else
-        \setbeamertemplate{background}{%
-          \begin{tikzpicture}[remember picture,overlay]
-            \node at (current page.center)
-              {\includegraphics[width=\paperwidth,height=\paperheight]%
-                {\bgpendingimage}};
-          \end{tikzpicture}}%
-      \fi
-    \else
-      \ifx\tmpbgsize\tmpcontain
-        \setbeamertemplate{background}{%
-          \begin{tikzpicture}[remember picture,overlay]
-            \node[opacity=\bgpendingopc] at (current page.center)
-              {\includegraphics[width=\paperwidth,height=\paperheight,
-                                keepaspectratio]{\bgpendingimage}};
-          \end{tikzpicture}}%
-      \else
-        \setbeamertemplate{background}{%
-          \begin{tikzpicture}[remember picture,overlay]
-            \node[opacity=\bgpendingopc] at (current page.center)
-              {\includegraphics[width=\paperwidth,height=\paperheight]%
-                {\bgpendingimage}};
-          \end{tikzpicture}}%
-      \fi
-    \fi
-    \global\bgpendingfalse
-    \global\bgopaquetrue
-    \global\bgactivetrue
+\newsavebox\bgmeasurebox
+\newcommand\bgcoverimage[1]{%
+  \sbox\bgmeasurebox{\includegraphics[width=\paperwidth]{#1}}%
+  \ifdim\ht\bgmeasurebox<\paperheight
+    \includegraphics[height=\paperheight]{#1}%
   \else
-    \ifbgactive
-      % Transitioning from a background slide to a plain slide: clear only the
-      % overlay layer so the theme's background canvas colour is preserved.
-      \setbeamertemplate{background}{}%
-      \global\bgactivefalse
-    \fi
-  \fi
-}]]
+    \usebox\bgmeasurebox
+  \fi}
+\newcommand\bgcontainimage[1]{%
+  \includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio]{#1}}
+% #1 = node options ([opacity=...] or empty), #2 = fit macro, #3 = image path
+\newcommand\bgoverlay[3]{%
+  \begin{tikzpicture}[remember picture,overlay]
+    \clip (current page.south west) rectangle (current page.north east);
+    \node#1 at (current page.center) {#2{#3}};
+  \end{tikzpicture}}
+\gdef\bgcurrent{}
+\setbeamertemplate{background}{\bgcurrent}
+% Every frame starts clean; a frame with a background re-arms \bgcurrent itself.
+\BeforeBeginEnvironment{frame}{\gdef\bgcurrent{}}
+% Section pages are reached through \frame{\sectionpage}, which the environment
+% hook above never sees. \beamer@atbeginsection runs after \c@section has been
+% stepped, so the section number selects the right stored background; sections
+% without one resolve to \relax and render nothing. Both hook variants are
+% patched because beamer picks between them on whether the section title is
+% blank.
+\makeatletter
+\preto\beamer@atbeginsection{%
+  \gdef\bgcurrent{\csname bgsection@\the\c@section\endcsname}}
+\preto\beamer@atbeginsections{%
+  \gdef\bgcurrent{\csname bgsection@\the\c@section\endcsname}}
+\makeatother]]
 
--- Generate title-slide background LaTeX.
---
--- Strategy (empirically proven; shipout hooks don't work with beamer):
---   \AtBeginDocument sets \setbeamertemplate{background} to the image (same
---   mechanism as per-slide backgrounds) and arms \bgactivetrue so the first
---   \begin{frame} resets it via the existing \BeforeBeginEnvironment hook.
---
---   Section-separator pages (\frame{\sectionpage}) don't trigger
---   \BeforeBeginEnvironment{frame}, so we use \makeatletter to prepend a
---   reset to beamer's internal \beamer@atbeginsection macro — this fires
---   before \frame{\sectionpage} is called, clearing the template in time.
-local function make_title_bg_latex(image, size, opacity)
-  size = size or "cover"
-
+-- The TikZ overlay for one background, with the image path baked in literally.
+-- Nothing here is read from a mutable macro, so one slide's background can
+-- never be confused with another's.
+local function overlay_latex(image, size, opacity)
   local node_opts = ""
   if not is_opaque(opacity) then
     node_opts = string.format("[opacity=%s]", opacity)
   end
+  local fit = (size == "contain") and "\\bgcontainimage" or "\\bgcoverimage"
+  return string.format("\\bgoverlay{%s}{%s}{%s}", node_opts, fit, image)
+end
 
-  local include_opts
-  if size == "contain" then
-    include_opts = "width=\\paperwidth,height=\\paperheight,keepaspectratio"
-  else
-    include_opts = "width=\\paperwidth,height=\\paperheight"
+-- Read background attributes off a heading, accepting the data- prefixed
+-- spellings reveal.js also allows.
+local function background_of(attr)
+  local function get(name)
+    return attr.attributes[name] or attr.attributes["data-" .. name]
   end
+  local image = get("background-image")
+  if not image then return nil end
+  return {
+    image   = resolve_image_path(image),
+    size    = get("background-size"),
+    opacity = get("background-opacity"),
+  }
+end
 
-  return string.format([[
-\AtBeginDocument{%%
-  \setbeamertemplate{background}{%%
-    \begin{tikzpicture}[remember picture,overlay]
-      \node%s at (current page.center)
-        {\includegraphics[%s]{%s}};
-    \end{tikzpicture}%%
-  }%%
-  \global\bgactivetrue
-}
-\makeatletter
-\preto\beamer@atbeginsection{%%
-  \setbeamertemplate{background}{}%%
-  \global\bgactivefalse
-}
-\makeatother]], node_opts, include_opts, image)
+local function strip_background_attrs(attr)
+  for _, name in ipairs({ "background-image", "background-size", "background-opacity" }) do
+    attr.attributes[name] = nil
+    attr.attributes["data-" .. name] = nil
+  end
 end
 
 -- Prepend an item to a MetaList (or create one from a single value).
@@ -200,76 +163,109 @@ local function prepend_header_include(meta, raw_latex)
   end
 end
 
+-- Title-slide background: \frame{\titlepage} has no body to write into, so set
+-- \bgcurrent at the start of the document and let the first \begin{frame} (or
+-- the first section page) clear it.
+local function title_bg_latex(bg)
+  return string.format("\\AtBeginDocument{\\gdef\\bgcurrent{%s}}",
+    overlay_latex(bg.image, bg.size, bg.opacity))
+end
+
+-- Section-page background, stored under the section number the heading will get.
+local function section_bg_latex(number, bg)
+  return string.format("\\expandafter\\gdef\\csname bgsection@%d\\endcsname{%s}",
+    number, overlay_latex(bg.image, bg.size, bg.opacity))
+end
+
+local function is_unnumbered(attr)
+  for _, class in ipairs(attr.classes) do
+    if class == "unnumbered" then return true end
+  end
+  return false
+end
+
 function Pandoc(doc)
   if FORMAT ~= "beamer" then return nil end
 
-  local new_blocks     = {}
-  local has_content_bg = false
+  local new_blocks    = {}
+  local section_bgs   = {}
+  local section_count = 0
+  local used          = false
 
-  -- Inject flag-setter raw blocks before each background-image heading.
   for _, block in ipairs(doc.blocks) do
-    if block.t == "Header" and (block.level == 1 or block.level == 2) then
-      local bg      = block.attr.attributes["background-image"]
-      local size    = block.attr.attributes["background-size"]
-      local opacity = block.attr.attributes["background-opacity"]
+    if block.t == "Header" and block.level == 1 then
+      -- Level 1 becomes \section, whose separator page is generated by beamer
+      -- rather than appearing in this block list. Count the sections that
+      -- \c@section will count, and file any background under that number.
+      local numbered = not is_unnumbered(block.attr)
+      if numbered then section_count = section_count + 1 end
 
+      local bg = background_of(block.attr)
       if bg then
-        has_content_bg = true
-
-        table.insert(new_blocks, pandoc.RawBlock("latex",
-          set_pending_latex(resolve_image_path(bg), size, opacity)))
-
-        -- Strip attrs so Beamer doesn't trip on unknown keys.
-        block.attr.attributes["background-image"]   = nil
-        block.attr.attributes["background-size"]    = nil
-        block.attr.attributes["background-opacity"] = nil
+        strip_background_attrs(block.attr)
+        if numbered then
+          used = true
+          table.insert(section_bgs, section_bg_latex(section_count, bg))
+        else
+          -- Unnumbered sections never advance \c@section, so there is no key to
+          -- file the background under. Drop it rather than mis-assign it.
+          io.stderr:write(string.format(
+            "[beamer-background] ignoring background on unnumbered section %q\n",
+            pandoc.utils.stringify(block.content)))
+        end
       end
-    end
+      table.insert(new_blocks, block)
 
-    table.insert(new_blocks, block)
+    elseif block.t == "Header" and block.level == 2 then
+      -- Level 2 becomes a frame. Arm the background as the first block of that
+      -- frame's own body, where no other slide can reach it.
+      local bg = background_of(block.attr)
+      table.insert(new_blocks, block)
+      if bg then
+        used = true
+        strip_background_attrs(block.attr)
+        table.insert(new_blocks, pandoc.RawBlock("latex",
+          string.format("\\gdef\\bgcurrent{%s}",
+            overlay_latex(bg.image, bg.size, bg.opacity))))
+      end
+
+    else
+      table.insert(new_blocks, block)
+    end
   end
 
-  -- Handle title-slide background from frontmatter title-slide-attributes.
-  -- \frame{\titlepage} does not trigger \BeforeBeginEnvironment{frame}, so we
-  -- set \setbeamertemplate{background} in \AtBeginDocument and rely on:
-  --   • \preto\beamer@atbeginsection — resets before section separator pages
-  --   • \BeforeBeginEnvironment{frame} + \bgactivetrue — resets on first content frame
+  -- Title slide background from the frontmatter.
+  local title_latex = nil
   local title_attrs = doc.meta["title-slide-attributes"]
-  local has_title_bg = false
-  local title_bg_latex = nil
-
   if title_attrs then
-    local title_bg      = nil
-    local title_size    = "cover"
-    local title_opacity = nil
-
+    local image, size, opacity
     for k, v in pairs(title_attrs) do
       local val = pandoc.utils.stringify(v)
       if k == "data-background-image" then
-        title_bg = val
+        image = val
       elseif k == "data-background-size" then
-        title_size = val
+        size = val
       elseif k == "data-background-opacity" then
-        title_opacity = val
+        opacity = val
       end
     end
-
-    if title_bg then
-      has_title_bg = true
-      title_bg_latex = make_title_bg_latex(
-        resolve_image_path(title_bg), title_size, title_opacity)
+    if image then
+      used = true
+      title_latex = title_bg_latex({
+        image = resolve_image_path(image), size = size, opacity = opacity,
+      })
     end
   end
 
-  -- PREAMBLE_HOOK provides the flags (\ifbgactive etc.) and the
-  -- \BeforeBeginEnvironment{frame} reset used by both per-slide and title bgs.
-  if has_content_bg or has_title_bg then
-    prepend_header_include(doc.meta, PREAMBLE_HOOK)
-  end
+  if not used then return nil end
 
-  if has_title_bg then
-    prepend_header_include(doc.meta, title_bg_latex)
+  -- Order matters: PREAMBLE defines \bgoverlay and the fit macros, so it is
+  -- prepended last to land above everything that calls them.
+  if title_latex then prepend_header_include(doc.meta, title_latex) end
+  for i = #section_bgs, 1, -1 do
+    prepend_header_include(doc.meta, section_bgs[i])
   end
+  prepend_header_include(doc.meta, PREAMBLE)
 
   return pandoc.Pandoc(new_blocks, doc.meta)
 end

--- a/lectures/01-example-lecture.md
+++ b/lectures/01-example-lecture.md
@@ -6,7 +6,7 @@ title-slide-attributes:
   data-background-size: cover
 ---
 
-# Basic Slides
+# Basic Slides {background-image="img/sullivans.jpg"}
 
 ## First Slide
 
@@ -49,6 +49,12 @@ Here's another one.
 Content can overlay a background image.
 
 Image of [Sullivans Creek, ANU Campus, Canberra](https://en.wikipedia.org/wiki/Sullivans_Creek).
+
+## Faded Background {background-image="img/dalmeny.jpg" background-opacity="0.4"}
+
+Neighbouring slides can use different images. `background-opacity` fades one back so heading text stays readable over a busy photo.
+
+`background-size="contain"` fits the whole image in rather than cropping it to fill.
 
 ## Speaker Notes
 


### PR DESCRIPTION
## The problem

`filters/beamer-background.lua` armed a single global `\bgpendingimage` before each frame, and had `\BeforeBeginEnvironment{frame}` install a background template that read it. The template body is only expanded at *shipout* though, and pandoc — not the filter — decides where frames begin and end. That indirection loses two races:

1. **A background lands on the wrong slide.** A raw block emitted before a heading is absorbed into the *previous* frame's body, so the next slide's `\gdef` runs before the current slide ships out and wins. The current slide renders its neighbour's image.
2. **An extra blank slide appears.** When a background heading opens the document there is no previous frame to absorb the block, so pandoc gives it a frame of its own.

Neither is visible in `01-example-lecture.md`, which has exactly one content background and doesn't start with it — that's why this shipped. A deck with two adjacent background slides reproduces both straight away.

Reproduced on `main` (9ea3d79) with a three-slide deck: page 2 is blank, and page 3 ("First slide, sullivans") renders the dalmeny bridge photo belonging to page 4.

| `main` | this branch |
|---|---|
| 5 pages for 3 slides + title; page 2 blank; first background slide shows the *next* slide's image | 4 pages; each slide shows its own image |

## The fix

Invert the mechanism so nothing is deferred. The template is installed once in the preamble as an indirection through `\bgcurrent`, and each frame sets `\bgcurrent` globally from *inside its own body*. A frame ships out at its `\end{frame}`, after its entire body has been read, so the value can't be clobbered by a later slide — and nothing extra enters the block stream, so there's no blank slide to create.

`\frame{\titlepage}` and `\frame{\sectionpage}` are the command form, so they never trip `\BeforeBeginEnvironment{frame}` and have no body to write into. Title slides use `\AtBeginDocument`; section pages are keyed by section number into `\beamer@atbeginsection`, which keeps them out of the block stream entirely.

The reasoning is written up in a strategy comment at the top of the filter, including *why* the obvious implementations fail — the failure modes are subtle enough to be worth recording.

This also drops the `\ifbgpending` / `\ifbgopaque` / `\ifbgactive` flag machinery and the four near-identical template variants it needed, and gains:

- **`#` section-page backgrounds**, which previously depended on the same lost race
- **`cover` that actually covers** — scale to fill and crop the overflow, instead of stretching the image to the slide. Previously a 3:2 photo on a 16:9 slide was visibly distorted
- **`data-` prefixed attribute spellings** on headings, which reveal.js also accepts

## Also here

- The beamer PDF rule now depends on the filter, and `filters/` is added to the CI path trigger and the build-cache key. A filter change alters every PDF without touching any `.md`, so without this a filter-only commit rebuilds nothing locally, and in CI restores stale PDFs from the cache that `git-restore-mtime` makes look newer than their sources.
- `pgf` listed explicitly in the tlmgr packages. It already arrives as a `beamer` dependency, but the filter uses `tikz` directly so it's worth being explicit.
- `CLAUDE.md` documents the heading attributes, `contain` vs `cover`, and `background-opacity` — only the frontmatter form was described before.

## Testing

`make public` from a clean tree, plus a deck covering every combination: title slide, background on the first slide, adjacent slides with different images, reset to a plain slide, section page, section *without* a background, `contain`, and `background-opacity`. Each renders its own image; no blank slides.

The example lecture is extended to exercise the cases that were broken — a section-page background, two neighbouring slides with different images, and `background-opacity` — so the template's own build would catch a regression. Happy to drop that commit's content if you'd rather keep the example minimal.

One known gap, called out in `CLAUDE.md`: a background on an `{.unnumbered}` `#` heading is skipped with a warning on stderr, since section pages are keyed by section number and unnumbered sections don't advance the counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
